### PR TITLE
Expose `notNull` so that a `_NotNull` prism can be made.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,8 @@
   ],
   "dependencies": {
     "purescript-maybe": "^2.0.0",
-    "purescript-functions": "^2.0.0"
+    "purescript-functions": "^2.0.0",
+    "purescript-isomorphisms": "^3.0.0"
   },
   "repository": {
     "type": "git",

--- a/src/Data/Nullable.purs
+++ b/src/Data/Nullable.purs
@@ -3,6 +3,7 @@
 
 module Data.Nullable
   ( Nullable
+  , isoNullableMaybe
   , toMaybe
   , toNullable
   ) where
@@ -11,6 +12,7 @@ import Prelude
 
 import Data.Function (on)
 import Data.Function.Uncurried (Fn3, runFn3)
+import Data.Iso (Iso(Iso))
 import Data.Maybe (Maybe(..), maybe)
 
 -- | A nullable type.
@@ -34,6 +36,9 @@ toNullable = maybe null notNull
 -- | Represent `null` using `Maybe a` as `Nothing`.
 toMaybe :: forall a. Nullable a -> Maybe a
 toMaybe n = runFn3 nullable n Nothing Just
+
+isoNullableMaybe :: forall a. Iso (Nullable a) (Maybe a)
+isoNullableMaybe = Iso toMaybe toNullable
 
 instance showNullable :: Show a => Show (Nullable a) where
   show = maybe "null" show <<< toMaybe


### PR DESCRIPTION
I was trying to construct a prism for Nullable JS data and exposing `notNull` seemed the most straightforward way to get the right type. This also give future users a prism to use.
