### PR TITLE
Add instances to `Nullable`

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,8 @@
   ],
   "dependencies": {
     "purescript-maybe": "^3.0.0",
-    "purescript-functions": "^3.0.0"
+    "purescript-functions": "^3.0.0",
+    "purescript-foldable-traversable": "^3.4.0"
   },
   "repository": {
     "type": "git",

--- a/src/Data/Nullable.purs
+++ b/src/Data/Nullable.purs
@@ -9,11 +9,19 @@ module Data.Nullable
 
 import Prelude
 
+import Control.Alt (class Alt, alt)
+import Control.Alternative (class Alternative)
+import Control.Extend (class Extend)
+import Control.Plus (class Plus)
 import Data.Eq (class Eq1)
+import Data.Foldable (class Foldable, foldMap, foldl, foldr)
 import Data.Function (on)
 import Data.Function.Uncurried (Fn3, runFn3)
 import Data.Maybe (Maybe(..), maybe)
+import Data.Monoid (class Monoid, mempty)
+import Data.Newtype (traverse)
 import Data.Ord (class Ord1)
+import Data.Traversable (class Traversable)
 
 -- | A nullable type.
 -- |
@@ -51,3 +59,45 @@ instance ordNullable :: Ord a => Ord (Nullable a) where
 
 instance ord1Nullable :: Ord1 Nullable where
   compare1 = compare
+
+instance semigroupNullable :: Semigroup a => Semigroup (Nullable a) where
+  append x y = toNullable (append (toMaybe x) (toMaybe y))
+
+instance monoidNullable :: Monoid (Nullable a) where
+  mempty = null
+
+instance functorNullable :: Functor Nullable where
+  map f = toNullable <<< map f <<< toMaybe
+
+instance foldableNullable :: Foldable Nullable where
+  foldMap f = foldMap f <<< toMaybe
+
+  foldl f acc = foldl f acc <<< toMaybe
+  foldr f acc = foldr f acc <<< toMaybe
+
+instance traversableNullable :: Traversable Nullable where
+  traverse f = toNullable <<< traverse f <<< toMaybe
+
+instance applyNullable :: Apply Nullable where
+  apply f x = toNullable $ (toMaybe f) `apply` (toMaybe x)
+
+instance applicativeNullable :: Applicative Nullable where
+  pure = notNull
+
+instance altNullable :: Alt Nullable where
+  alt x y = toNullable $ (toMaybe x) `alt` (toMaybe y)
+
+instance plusNullable :: Plus Nullable where
+  empty = null
+
+instance alternativeNullable :: Alternative Nullable
+
+instance bindNullable :: Bind Nullable where
+  bind x f = toNullable $ (toMaybe x) >>= (toMaybe <<< f)
+
+instance monadNullable :: Monad Nullable
+
+instance extendNullable :: Extend Nullable where
+  extend f x = case toMaybe x of
+    Just value -> notNull (f x)
+    Nothing    -> null


### PR DESCRIPTION
Adding a load of missing instances to `Nullable`. Unfortunately, a couple of these are necessary for us, but I think they're all correct. Not that I'm _advocating_ their use, of course...