### PR TITLE
Fix broken "Module Documentation" link in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ A library for dealing with null values in foreign libraries.
 
     bower i purescript-nullable
 
-- [Module Documentation](https://pursuit.purescript.org/packages/purescript-nullable/1.0.1/docs/Data.Nullable)
+- [Module Documentation](https://pursuit.purescript.org/packages/purescript-nullable)


### PR DESCRIPTION
Hey there,

The "Module Documentation" link in `README.md` currently points to version 1.0.1 of the library on pursuit, but it looks like that version no longer exists there.

This PR just uses pursuit's version redirect behavior to fix the link.

Thanks!