### PR TITLE
Export null and notNull.

### DIFF
--- a/src/Data/Nullable.purs
+++ b/src/Data/Nullable.purs
@@ -3,6 +3,8 @@
 
 module Data.Nullable
   ( Nullable
+  , null
+  , notNull
   , toMaybe
   , toNullable
   ) where


### PR DESCRIPTION
I find myself writing `toNullable Nothing` and `toNullable $ Just something` and it would be rad if I could use `null` and `notNull something` instead.