### PR TITLE
Monad instance

### DIFF
--- a/src/Data/Nullable.purs
+++ b/src/Data/Nullable.purs
@@ -53,3 +53,18 @@ instance ordNullable :: Ord a => Ord (Nullable a) where
 
 instance ord1Nullable :: Ord1 Nullable where
   compare1 = compare
+
+instance nullableFunctor :: Functor Nullable where
+  map f a = runFn3 nullable a null (notNull <<< f)
+
+instance applyNullable :: Apply Nullable where
+  apply nf na = runFn3 nullable nf null \f ->
+    runFn3 nullable na null \a -> notNull (f a)
+
+instance applicativeNullable :: Applicative Nullable where
+  pure = notNull
+
+instance bindNullable :: Bind Nullable where
+  bind n f = runFn3 nullable n null (f $ _)
+
+instance monadNullable :: Monad Nullable


### PR DESCRIPTION
Please excuse my ignorance, but I can't see a reason why Nullable,
effectively equal to Maybe, isn't at least a Functor or actually a Monad.
The instance definitions follow quite naturally.  I can imagine
this is sort of an artificial barrier to foreign values.  However,
to/from maybe conversion for the sake of using one of these instances
seems just wasteful for no particular good reason.

If I am overseeing something blatantly obvious here, it might
be good to document why this is not desireable/allowed.