### PR TITLE
Add isomorphism for `Nullable` and `Maybe`

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,9 +19,11 @@
   ],
   "dependencies": {
     "purescript-maybe": "^4.0.0",
-    "purescript-functions": "^4.0.0"
+    "purescript-functions": "^4.0.0",
+    "purescript-profunctor-lenses": "^6.2.0"
   },
   "devDependencies": {
-    "purescript-assert": "^4.0.0"
+    "purescript-assert": "^4.0.0",
+    "purescript-psci-support": "^4.0.0"
   }
 }

--- a/src/Data/Nullable.purs
+++ b/src/Data/Nullable.purs
@@ -7,6 +7,7 @@ module Data.Nullable
   , notNull
   , toMaybe
   , toNullable
+  , _maybe
   ) where
 
 import Prelude
@@ -14,6 +15,7 @@ import Prelude
 import Data.Eq (class Eq1)
 import Data.Function (on)
 import Data.Function.Uncurried (Fn3, runFn3)
+import Data.Lens (Iso, iso)
 import Data.Maybe (Maybe(..), maybe)
 import Data.Ord (class Ord1)
 
@@ -60,6 +62,23 @@ toNullable = maybe null notNull
 -- | its argument (see the warning about the pitfall of `Nullable` above).
 toMaybe :: forall a. Nullable a -> Maybe a
 toMaybe n = runFn3 nullable n Nothing Just
+
+-- | An isomorphism between `Nullable` and `Maybe`. Note that this optic 
+-- | may not be law-abiding (see the warning about the pitfall of `Nullable`
+-- | above). Can be used with iso-compatible functions like `view` and `review`:
+-- |
+-- | ```purs
+-- | > view _maybe (notNull 10) :: Maybe Int
+-- | Just 10
+-- |
+-- | > review _maybe (Just 10) :: Nullable Int
+-- | 10 -- `Nullable` not displayed in the repl due to its `Show` instance
+-- |
+-- | > review _maybe Nothing :: Nullable Int
+-- | null
+-- | ```
+_maybe :: forall a b. Iso (Nullable a) (Nullable b) (Maybe a) (Maybe b)
+_maybe = iso toMaybe toNullable
 
 instance showNullable :: Show a => Show (Nullable a) where
   show = maybe "null" show <<< toMaybe


### PR DESCRIPTION
## What does this pull request do?

Closes #12 (originally #8) by introducing an iso for `Nullable` and `Maybe`. Introduces a new dependency, `profunctor-lenses`, to support this change, which is a part of `-contrib` and therefore acceptable as a dependency.

## Where should the reviewer start?

Please review the `_maybe` iso:

1. Is the name `_maybe` acceptable?
2. Is the documentation comment accurate?

## How should this be manually tested?

I tested this in the repl and didn't notice anything amiss.

## Other Notes:

Introducing a new dependency will require a new version of `Nullable` to accommodate the change. If any other breaking changes have been planned but abandoned in the past I'm happy to push them through at this time to make a single breaking release.