### PR TITLE
Add roles declarations to allow safe coercions

### DIFF
--- a/packages.dhall
+++ b/packages.dhall
@@ -1,4 +1,4 @@
 let upstream =
-      https://raw.githubusercontent.com/purescript/package-sets/prepare-0.14/src/packages.dhall sha256:f9b49a477fcd822a7119413b689123f8e1694b0008c156971f1931751079a56f
+      https://raw.githubusercontent.com/purescript/package-sets/prepare-0.14/src/packages.dhall
 
 in  upstream

--- a/src/Data/Nullable.purs
+++ b/src/Data/Nullable.purs
@@ -43,6 +43,8 @@ import Data.Ord (class Ord1)
 -- | not provided.
 foreign import data Nullable :: Type -> Type
 
+type role Nullable representational
+
 -- | The null value.
 foreign import null :: forall a. Nullable a
 


### PR DESCRIPTION
This allows terms of type `Nullable a` to be coerced to type `Nullable b` when `Coercible a b` holds, hence allowing the zero cost `coerce` to introduce and eliminate newtypes under nullable values for instance.
