### PR TITLE
Update README.md docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ spago install nullable
 
 ## Quick start
 
-The quick start hasn't been written yet (contributions are welcome!). The quick start covers a common, minimal use case for the library, whereas longer examples and tutorials are kept in the [docs directory](./docs.)
+The quick start hasn't been written yet (contributions are welcome!). The quick start covers a common, minimal use case for the library, whereas longer examples and tutorials are kept in the [docs directory](./docs).
 
 ## Documentation
 


### PR DESCRIPTION
First action after skimming  the README is to click the docs link there but is broken now, so this PR fixes it.