### PR TITLE
Match repository URL in `bower.json` with the one in the registry

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git://github.com/purescript-contrib/purescript-nullable.git"
+    "url": "https://github.com/paf31/purescript-nullable.git"
   },
   "ignore": [
     "**/.*",


### PR DESCRIPTION
This PR updates the repository URL to match the one in the [PureScript registry](https://github.com/purescript/registry/blob/master/bower-packages.json#L867).

At time of writing, these URLs have to match in order to publish new package versions.